### PR TITLE
🎨 Ensure that collections are always instances of `Illuminate\Support\Collection`

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -9,16 +9,16 @@
     "packages-dev": [
         {
             "name": "laravel/pint",
-            "version": "v1.13.7",
+            "version": "v1.13.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/pint.git",
-                "reference": "4157768980dbd977f1c4b4cc94997416d8b30ece"
+                "reference": "e3e269cc5d874c8efd2dc7962b1c7ff2585fe525"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/pint/zipball/4157768980dbd977f1c4b4cc94997416d8b30ece",
-                "reference": "4157768980dbd977f1c4b4cc94997416d8b30ece",
+                "url": "https://api.github.com/repos/laravel/pint/zipball/e3e269cc5d874c8efd2dc7962b1c7ff2585fe525",
+                "reference": "e3e269cc5d874c8efd2dc7962b1c7ff2585fe525",
                 "shasum": ""
             },
             "require": {
@@ -29,13 +29,13 @@
                 "php": "^8.1.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.38.0",
-                "illuminate/view": "^10.30.1",
+                "friendsofphp/php-cs-fixer": "^3.47.0",
+                "illuminate/view": "^10.40.0",
+                "larastan/larastan": "^2.8.1",
                 "laravel-zero/framework": "^10.3.0",
-                "mockery/mockery": "^1.6.6",
-                "nunomaduro/larastan": "^2.6.4",
+                "mockery/mockery": "^1.6.7",
                 "nunomaduro/termwind": "^1.15.1",
-                "pestphp/pest": "^2.24.2"
+                "pestphp/pest": "^2.31.0"
             },
             "bin": [
                 "builds/pint"
@@ -71,7 +71,7 @@
                 "issues": "https://github.com/laravel/pint/issues",
                 "source": "https://github.com/laravel/pint"
             },
-            "time": "2023-12-05T19:43:12+00:00"
+            "time": "2024-01-16T17:39:29+00:00"
         }
     ],
     "aliases": [],

--- a/src/AcornPrettify.php
+++ b/src/AcornPrettify.php
@@ -4,10 +4,13 @@ namespace Roots\AcornPrettify;
 
 use Illuminate\Support\Collection;
 use Roots\Acorn\Application;
+use Roots\AcornPrettify\Concerns\HasCollection;
 use Roots\AcornPrettify\Modules\AbstractModule;
 
 class AcornPrettify
 {
+    use HasCollection;
+
     /**
      * The Application instance.
      */
@@ -35,11 +38,11 @@ class AcornPrettify
     public function __construct(Application $app)
     {
         $this->app = $app;
-        $this->config = collect(
+        $this->config = $this->collect(
             $this->app->config->get('prettify', [])
-        )->map(fn ($value) => collect($value));
+        )->map(fn ($value) => $this->collect($value));
 
-        add_filter('init', fn () => collect($this->modules)
+        add_filter('init', fn () => $this->collect($this->modules)
             ->reject(fn ($module) => $module instanceof AbstractModule)
             ->each(fn ($module) => $module::make($this->app, $this->config))
         );

--- a/src/Concerns/HasCollection.php
+++ b/src/Concerns/HasCollection.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Roots\AcornPrettify\Concerns;
+
+use Illuminate\Support\Collection;
+
+trait HasCollection
+{
+    /**
+     * Create a collection from the given value.
+     *
+     * @param  mixed  $value
+     * @return \Illuminate\Support\Collection
+     */
+    protected function collect($value = [])
+    {
+        return Collection::make($value);
+    }
+}

--- a/src/Modules/CleanUpModule.php
+++ b/src/Modules/CleanUpModule.php
@@ -3,10 +3,13 @@
 namespace Roots\AcornPrettify\Modules;
 
 use Illuminate\Support\Str;
+use Roots\AcornPrettify\Concerns\HasCollection;
 use Roots\AcornPrettify\Document;
 
 class CleanUpModule extends AbstractModule
 {
+    use HasCollection;
+
     /**
      * Handle the module.
      */
@@ -205,7 +208,7 @@ class CleanUpModule extends AbstractModule
             $disallowedClasses[] = 'page-id-'.get_option('page_on_front');
         }
 
-        return collect($classes)
+        return $this->collect($classes)
             ->diff($disallowedClasses)
             ->values()
             ->all();


### PR DESCRIPTION
`collect()` can be unreliable when we are using types for things like the `$config` property.