### PR TITLE
Update README.md to be more clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Acorn Prettify contains a collection of modules to apply theme-agnostic front-en
 Install via Composer:
 
 ```sh
-$ composer require roots/acorn-prettify
+composer require roots/acorn-prettify
 ```
 
 ## Features
@@ -35,7 +35,13 @@ $ composer require roots/acorn-prettify
 Start by publishing the package configuration:
 
 ```sh
-$ wp acorn vendor:publish --tag=prettify-config
+wp acorn vendor:publish --tag=prettify-config
+```
+
+If this says there are no publishable tags, you may not have initialized Acorn yet:
+
+```sh
+wp acorn acorn:init storage
 ```
 
 Review the published config file to get an understanding of the optimizations that Acorn Prettify has enabled out of the box.


### PR DESCRIPTION
Multiple people have ran into the issue where it says there are no publishable tags. This is due to no where in the Sage Install page or Acorn Install page mentioning a command that is required before you can publish any tags.

Added the missing command here as a note.

Also removed the extra $ since the markdown already indicates these are sh commands, so that the "Copy" button copies the exact code to be ran without including the extra $ in your clipboard that will need deleted when pasted.